### PR TITLE
Fake links to enable toggle with mouseless browsers

### DIFF
--- a/src/main/webapp/macro/fragment-parts.vm
+++ b/src/main/webapp/macro/fragment-parts.vm
@@ -65,6 +65,8 @@
 
 #set ($fragmentHeadline = false)
 #set ($fragmentHeadline = $fragment.makeHeadline(20))
+<a href="#" onclick='javascript: $(this).parent().find("span.fragment-tools").toggle();'
+   style="float: right;"><!-- link to enable mouse-less browsers to toggle fragment-tools --></a>
 <span class="fragment-tools">
   <span class="fragment-id" style="display: none;">$fragment.id</span>
   #if ($fragmentHeadline)

--- a/src/main/webapp/macro/fragments.vm
+++ b/src/main/webapp/macro/fragments.vm
@@ -35,7 +35,9 @@ jQuery(function() {
 		<span class="title" style="line-height: 24px;">All</span>:
 		<span class="count"></span>
     <span class="toggle" style="display: none;">
-      <img border="0" alt="" src="$context/style/images/bullet-arrow-down.png"/>
+      <a href="#" onclick='javascript: $("div.view-header").find("div.fragments-criteria").toggle();'><!--
+         link to enable mouse-less browsers to toggle fragments-criteria
+      --><img border="0" alt="" src="$context/style/images/bullet-arrow-down.png"/></a>
     </span>
 	</span>
 	#if ($jsAddFragment)


### PR DESCRIPTION
1. The toggle button (up/down arrow) in view-header can now be accessed as a (JS) link.
2. The fragment-tools can be toggled by an (empty) link at the right end of fragment-header
   Note: It is floated right to make it not collide with fragment id link.
         This will need to be fixed for RTL languages.

A bit hacky (I'm not fluent in JavaScript) but it works.
Feel free to clean up/improve...

Tested with dwb.
## User HowTo:

How to use it with dwb browser:

User loads piggydb and scrolls to the view-header:
![pdb_b1_1](https://cloud.githubusercontent.com/assets/6317321/4773965/884b9ea8-5ba8-11e4-8d02-c57f06faf5b1.png)
User presses 'f' for 'follow hints', i.e. show labels on links that can be activated:
![pdb_b1_2](https://cloud.githubusercontent.com/assets/6317321/4773966/88552018-5ba8-11e4-9e5d-481e434c75aa.png)
User types BD (code where the down-arrow is). The fragments-criteria is made visible:
![pdb_b1_3](https://cloud.githubusercontent.com/assets/6317321/4773967/887e9e98-5ba8-11e4-949d-7e216ef645ee.png)

User has a fragment header visible that they want to invoke the tools on:
![pdb_b2_1](https://cloud.githubusercontent.com/assets/6317321/4773968/885280ce-5ba8-11e4-8e59-8fd82f76f8ee.png)
User presses 'f' for 'follow hints', i.e. show labels on links that can be activated:
![pdb_b2_2](https://cloud.githubusercontent.com/assets/6317321/4773969/888cbf78-5ba8-11e4-9461-8ff73e52f279.png)
User chooses DR and the tools appear.
![pdb_b2_3](https://cloud.githubusercontent.com/assets/6317321/4773970/885c8588-5ba8-11e4-8af6-ae5623908dff.png)
User can similarly again hide the tools.

PS: To improve our common knowledge network: see also note on interfaces and API for future version 7 in http://piggydb.lighthouseapp.com/projects/61149/tickets/68-accessibility-issues#ticket-68-2
